### PR TITLE
(Partial) 1.17 Update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,24 @@
 plugins {
-	id 'fabric-loom' version '0.5-SNAPSHOT'
+	id 'fabric-loom' version '0.8-SNAPSHOT'
 	id 'maven-publish'
 }
 
 apply plugin: 'idea'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
+
+// Select the repositories you want to publish to
+// To publish to maven local, no extra repositories are necessary. Just use the task `publishToMavenLocal`.
+repositories {
+	// See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
+	maven { url "https://maven.shedaniel.me/" }
+	maven { url "https://maven.terraformersmc.com/releases/" }
+}
 
 dependencies {
 	// To change the versions see the gradle.properties file
@@ -21,12 +29,12 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modApi("me.sargunvohra.mcmods:autoconfig1u:3.3.1") {
+	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
-	include "me.sargunvohra.mcmods:autoconfig1u:3.3.1"
+	include "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}"
 
-	modApi("io.github.prospector:modmenu:1.14.6+build.31") {
+	modApi("com.terraformersmc:modmenu:2.0.2") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 }
@@ -80,11 +88,5 @@ publishing {
 				builtBy remapSourcesJar
 			}
 		}
-	}
-
-	// Select the repositories you want to publish to
-	// To publish to maven local, no extra repositories are necessary. Just use the task `publishToMavenLocal`.
-	repositories {
-		// See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,18 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.16.4
-	yarn_mappings=1.16.4+build.6
-	loader_version=0.10.6+build.214
+	minecraft_version=1.17
+	yarn_mappings=1.17+build.13
+	loader_version=0.11.6
 
 # Mod Properties
-	mod_version = 1.2.2
-	maven_group = net.fabricmc
+	mod_version = 1.2.2-1.17
+	maven_group = pepjebs
 	archives_base_name = chorus-links
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.25.1+build.416-1.16
+	fabric_version = 0.36.0+1.17
+	cloth_version = 5.0.34

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/java/pepjebs/choruslinks/ChorusLinksMod.java
+++ b/src/main/java/pepjebs/choruslinks/ChorusLinksMod.java
@@ -1,9 +1,10 @@
 package pepjebs.choruslinks;
 
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-import me.sargunvohra.mcmods.autoconfig1u.serializer.JanksonConfigSerializer;
+import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
 import net.fabricmc.fabric.api.tool.attribute.v1.FabricToolTags;
 import net.minecraft.block.Block;
 import net.minecraft.block.Material;
@@ -63,6 +64,6 @@ public class ChorusLinksMod implements ModInitializer {
         CHORUS_LINK_BLOCK_ENTITY_TYPE = Registry.register(
                 Registry.BLOCK_ENTITY_TYPE,
                 new Identifier(MOD_ID, "chorus_link_type"),
-                BlockEntityType.Builder.create(ChorusLinkBlockEntity::new, chorus_link).build(null));
+                FabricBlockEntityTypeBuilder.create(ChorusLinkBlockEntity::new, chorus_link).build(null));
     }
 }

--- a/src/main/java/pepjebs/choruslinks/block/ChorusLinkBlock.java
+++ b/src/main/java/pepjebs/choruslinks/block/ChorusLinkBlock.java
@@ -2,7 +2,9 @@ package pepjebs.choruslinks.block;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockEntityProvider;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
 import org.jetbrains.annotations.Nullable;
 import pepjebs.choruslinks.block.entity.ChorusLinkBlockEntity;
@@ -15,7 +17,7 @@ public class ChorusLinkBlock extends Block implements BlockEntityProvider {
 
     @Nullable
     @Override
-    public BlockEntity createBlockEntity(BlockView world) {
-        return new ChorusLinkBlockEntity();
+    public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
+        return new ChorusLinkBlockEntity(pos, state);
     }
 }

--- a/src/main/java/pepjebs/choruslinks/block/entity/ChorusLinkBlockEntity.java
+++ b/src/main/java/pepjebs/choruslinks/block/entity/ChorusLinkBlockEntity.java
@@ -1,10 +1,13 @@
 package pepjebs.choruslinks.block.entity;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.util.math.BlockPos;
 import pepjebs.choruslinks.ChorusLinksMod;
+import pepjebs.choruslinks.block.ChorusLinkBlock;
 
 public class ChorusLinkBlockEntity extends BlockEntity {
-    public ChorusLinkBlockEntity() {
-        super(ChorusLinksMod.CHORUS_LINK_BLOCK_ENTITY_TYPE);
+    public ChorusLinkBlockEntity(BlockPos pos, BlockState state) {
+        super(ChorusLinksMod.CHORUS_LINK_BLOCK_ENTITY_TYPE, pos, state);
     }
 }

--- a/src/main/java/pepjebs/choruslinks/config/ChorusLinksConfig.java
+++ b/src/main/java/pepjebs/choruslinks/config/ChorusLinksConfig.java
@@ -1,9 +1,9 @@
 package pepjebs.choruslinks.config;
 
-import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.ConfigEntry;
-import me.sargunvohra.mcmods.autoconfig1u.shadowed.blue.endless.jankson.Comment;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
 import pepjebs.choruslinks.ChorusLinksMod;
 
 @Config(name = ChorusLinksMod.MOD_ID)

--- a/src/main/java/pepjebs/choruslinks/config/ChorusLinksModMenuApiImpl.java
+++ b/src/main/java/pepjebs/choruslinks/config/ChorusLinksModMenuApiImpl.java
@@ -2,7 +2,7 @@ package pepjebs.choruslinks.config;
 
 import io.github.prospector.modmenu.api.ConfigScreenFactory;
 import io.github.prospector.modmenu.api.ModMenuApi;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 
 public class ChorusLinksModMenuApiImpl implements ModMenuApi {
 

--- a/src/main/java/pepjebs/choruslinks/item/GoldenChorusFruitItem.java
+++ b/src/main/java/pepjebs/choruslinks/item/GoldenChorusFruitItem.java
@@ -4,7 +4,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.*;
-import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
@@ -111,7 +111,7 @@ public class GoldenChorusFruitItem extends Item {
             BlockPos pos = context.getBlockPos();
             BlockState state = context.getWorld().getBlockState(pos);
             if (state.getBlock() instanceof ChorusLinkBlock) {
-                CompoundTag tag = context.getStack().getOrCreateTag();
+                NbtCompound tag = context.getStack().getOrCreateTag();
                 tag.putIntArray(GOLDEN_CHORUS_BIND_POS_TAG, Arrays.asList(pos.getX(), pos.getY(), pos.getZ()));
                 tag.putString(GOLDEN_CHORUS_BIND_DIM_TAG, context.getWorld().getRegistryKey().getValue().toString());
                 context.getStack().setTag(tag);

--- a/src/main/java/pepjebs/choruslinks/utils/ChorusLinksUtils.java
+++ b/src/main/java/pepjebs/choruslinks/utils/ChorusLinksUtils.java
@@ -47,10 +47,10 @@ public class ChorusLinksUtils {
                         return new Pair<>(doChorusLinkSearch(stack, world, user), (ServerWorld) world);
                     }
                 }
-                if (!world.isChunkLoaded(blockPos)) {
+                if (!world.isChunkLoaded(blockPos.getX() >> 4, blockPos.getZ() >> 4)) {
                     world.getChunk(blockPos.getX() >> 4, blockPos.getZ() >> 4);
                 }
-                if (world.isChunkLoaded(blockPos)
+                if (world.isChunkLoaded(blockPos.getX() >> 4, blockPos.getZ() >> 4)
                         && world.getBlockState(blockPos).getBlock() instanceof ChorusLinkBlock) {
                     return new Pair<>(blockPos, (ServerWorld) world);
                 }
@@ -58,7 +58,7 @@ public class ChorusLinksUtils {
         }
         return new Pair<>(doChorusLinkSearch(stack, world, user), (ServerWorld) world);
     }
-
+//FIXME: change ChorusLink search logic
     public static BlockPos doChorusLinkSearch(ItemStack stack, World world, ServerPlayerEntity user) {
         List<ChorusLinkBlockEntity> chorusLinks = world.blockEntities
                 .stream()
@@ -73,7 +73,7 @@ public class ChorusLinksUtils {
         }
         for (ChorusLinkBlockEntity link : chorusLinks) {
             BlockPos targetPos = link.getPos();
-            if (targetPos.isWithinDistance(user.getPos(), radius) && world.isChunkLoaded(targetPos)) {
+            if (targetPos.isWithinDistance(user.getPos(), radius) && world.isChunkLoaded(targetPos.getX() >> 4, targetPos.getZ() >> 4)) {
                 BlockState state = world.getBlockState(targetPos);
                 if (world.getReceivedStrongRedstonePower(targetPos) != 0) continue;
                 double playerDist = targetPos.getSquaredDistance(user.getPos(), true);
@@ -99,7 +99,7 @@ public class ChorusLinksUtils {
 
     public static void doChorusLinkTeleport(ItemStack usingStack, ServerWorld world, ServerPlayerEntity user, BlockPos blockPos) {
         if (world.getRegistryKey().getValue().toString().compareTo(user.world.getRegistryKey().getValue().toString()) != 0) {
-            user.teleport(world, blockPos.getX(), blockPos.getY(), blockPos.getZ(), user.yaw, user.pitch);
+            user.teleport(world, blockPos.getX(), blockPos.getY(), blockPos.getZ(), user.getYaw(), user.getPitch());
         }
         if (user.hasVehicle()) {
             user.stopRiding();
@@ -120,7 +120,7 @@ public class ChorusLinksUtils {
         for(int i = 0; i < 16; ++i) {
             double g = user.getX() + (user.getRandom().nextDouble() - 0.5D) * 16.0D;
             double h = MathHelper.clamp(user.getY() +
-                    (double)(user.getRandom().nextInt(16) - 8), 0.0D, (world.getDimensionHeight() - 1));
+                    (double)(user.getRandom().nextInt(16) - 8), 0.0D, (world.getDimension().getHeight() - 1));
             double j = user.getZ() + (user.getRandom().nextDouble() - 0.5D) * 16.0D;
             if (user.hasVehicle()) {
                 user.stopRiding();

--- a/src/main/resources/choruslinks.mixins.json
+++ b/src/main/resources/choruslinks.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "pepjebs.choruslinks.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_16",
   "mixins": [
     "ChorusFruitItemMixin"
   ],

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,8 +26,9 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.7.4",
+    "fabricloader": ">=0.11.6",
     "fabric": "*",
-    "minecraft": "1.16.x"
+    "minecraft": "1.17.x",
+    "java": ">=16"
   }
 }


### PR DESCRIPTION
Most of the needed updates are done, the only part that is missing is [ChorusLinkUtils#doChorusLinkSearch](https://github.com/CamperSamu/ChorusLinks/blob/f37eda3f02c2fb676591edc7b5480edc3ada1ad2/src/main/java/pepjebs/choruslinks/utils/ChorusLinksUtils.java#L61), the list blockEntities list got removed and I decided to not touch it and discuss a viable good method to find the nearest chorus link first.
An ok idea would be to gradually search in the nearest chunks (because the blockEntities list is still present there) to the player until the max range of block is covered, compile a list of the various links found and find the closest one.

I partially switched to ClothConfig instead of autoconfig since it's deprecated, but the project is still using the AutoConfig included inside ClothConfig API, so basically nothing has changed (but some stuff is deprecated and _should_ be changed).